### PR TITLE
Changed Sample Target Version to Latest .NET9 Target Version.

### DIFF
--- a/ListViewMaui/ListViewMaui/App.xaml.cs
+++ b/ListViewMaui/ListViewMaui/App.xaml.cs
@@ -5,7 +5,10 @@ public partial class App : Application
 	public App()
 	{
 		InitializeComponent();
+	}
 
-		MainPage = new MainPage();
+	protected override Window CreateWindow(IActivationState? activationState)
+	{
+		return new Window(new MainPage());
 	}
 }

--- a/ListViewMaui/ListViewMaui/ListViewMaui.csproj
+++ b/ListViewMaui/ListViewMaui/ListViewMaui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ListViewMaui</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -46,6 +46,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Syncfusion.Maui.ListView" Version="*" />
 	</ItemGroup>
 


### PR DESCRIPTION
**Description**
Changed Sample Target Version to Latest .NET9 Target Version.
[Task 952326](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/952326): Migrate net6 & net7 samples to latest version